### PR TITLE
Fixing bug with DnD zone after uploading a file

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,13 @@
-* { box-sizing: border-box }
-html, body { height: 100%; }
+* { box-sizing: border-box; }
+
+html,
+body { height: 100%; }
+
 body {
   font-family: sans-serif;
   margin: 0;
   padding: 0;
 }
-
 
 /**
  * Main App container
@@ -22,7 +24,6 @@ body {
   padding-top: 2rem;
   background-color: white;
 }
-
 
 /**
  * Drag and Drop component
@@ -42,11 +43,12 @@ body {
   background-color: rgba(255, 255, 255, 0.9);
 }
 
-.DropTarget.is-hidden {
+.DropTarget.is-hidden,
+.DropTargetOverlay.is-hidden {
+  display: none;
   z-index: -1;
   opacity: 0;
 }
-
 
 /**
  * The overlay is needed for when there are iframes
@@ -63,7 +65,6 @@ body {
 }
 
 .DropTargetOverlay:hover { display: none; }
-
 
 /**
  * File picker component

--- a/src/lib/drag-drop.js
+++ b/src/lib/drag-drop.js
@@ -44,7 +44,7 @@ export default function initialize(onSuccess, onFail, preventLoad) {
       node.parentNode.removeChild(node);
       overlay.parentNode.removeChild(overlay);
     },
-    show: () => node.classList.remove("is-hidden"),
-    hide: () => node.classList.add("is-hidden")
+    show: () => { node.classList.remove('is-hidden'); overlay.classList.remove('is-hidden'); },
+    hide: () => { node.classList.add('is-hidden'); overlay.classList.add('is-hidden'); }
   };
 }

--- a/src/lib/drag-drop.js
+++ b/src/lib/drag-drop.js
@@ -44,7 +44,7 @@ export default function initialize(onSuccess, onFail, preventLoad) {
       node.parentNode.removeChild(node);
       overlay.parentNode.removeChild(overlay);
     },
-    show: () => { node.classList.remove('is-hidden'); overlay.classList.remove('is-hidden'); },
-    hide: () => { node.classList.add('is-hidden'); overlay.classList.add('is-hidden'); }
+    show: () => { node.classList.remove("is-hidden"); overlay.classList.remove("is-hidden"); },
+    hide: () => { node.classList.add("is-hidden"); overlay.classList.add("is-hidden"); }
   };
 }


### PR DESCRIPTION
# Why
Previously, after uploading a file, the drag and drop layer would swallow most events and make the viewer unusable. This is caused by the DropTargetOverlay only visually disappearing, and attempting to move itself under the current layers with ```z-index: -1;```.

# The Change
Having the `.is-hidden` class add ```display: none``` as well as having the `drag-drop#hide` function also add `.is-hidden` to the overlay solves this issue while maintaining the original intended use case.